### PR TITLE
add environment variables

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,9 +2,32 @@
 
 
 [[projects]]
+  name = "github.com/fsnotify/fsnotify"
+  packages = ["."]
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  version = "v1.4.7"
+
+[[projects]]
   name = "github.com/golang/protobuf"
   packages = ["proto"]
   revision = "925541529c1fa6821df4e44ce2723319eb2be768"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/hashicorp/hcl"
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/printer",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
+  revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
   version = "v1.0.0"
 
 [[projects]]
@@ -14,10 +37,28 @@
   version = "v1.0"
 
 [[projects]]
+  name = "github.com/magiconair/properties"
+  packages = ["."]
+  revision = "c2353362d570a7bfa228149c62842019201cfb71"
+  version = "v1.8.0"
+
+[[projects]]
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
   revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
   version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/mitchellh/mapstructure"
+  packages = ["."]
+  revision = "3536a929edddb9a5b34bd6861dc4a9647cb459fe"
+  version = "v1.1.2"
+
+[[projects]]
+  name = "github.com/pelletier/go-toml"
+  packages = ["."]
+  revision = "c01d1270ff3e442a8a57cddc1c92dc1138598194"
+  version = "v1.2.0"
 
 [[projects]]
   name = "github.com/pkg/errors"
@@ -34,7 +75,11 @@
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/common"
-  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model"
+  ]
   revision = "89604d197083d4781071d3c65855d24ecfb0a563"
 
 [[projects]]
@@ -44,16 +89,43 @@
   version = "v1.0.4"
 
 [[projects]]
+  name = "github.com/spf13/afero"
+  packages = [
+    ".",
+    "mem"
+  ]
+  revision = "a5d6946387efe7d64d09dcba68cdd523dc1273a3"
+  version = "v1.2.0"
+
+[[projects]]
+  name = "github.com/spf13/cast"
+  packages = ["."]
+  revision = "8c9545af88b134710ab1cd196795e7f2388358d7"
+  version = "v1.3.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/spf13/cobra"
   packages = ["."]
   revision = "be77323fc05148ef091e83b3866c0d47c8e74a8b"
 
 [[projects]]
+  name = "github.com/spf13/jwalterweatherman"
+  packages = ["."]
+  revision = "4a4406e478ca629068e7768fc33f3f044173c0a6"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/spf13/pflag"
   packages = ["."]
   revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
   version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/spf13/viper"
+  packages = ["."]
+  revision = "6d33b5a963d922d182c91e8a1c88d81fd150cfd4"
+  version = "v1.3.1"
 
 [[projects]]
   branch = "master"
@@ -64,8 +136,24 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "37707fdb30a5b38865cfb95e5aab41707daec7fd"
+
+[[projects]]
+  name = "golang.org/x/text"
+  packages = [
+    "internal/gen",
+    "internal/triegen",
+    "internal/ucd",
+    "transform",
+    "unicode/cldr",
+    "unicode/norm"
+  ]
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
 
 [[projects]]
   branch = "v2"
@@ -76,6 +164,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3abd0cc431decbb566d1be7247d1fd98dec30b86b826abc1b84c45dafc92c190"
+  inputs-digest = "0cd4b0fb858b550e04e72c7e12a4240acf5f606484728c17a2fc735942e0ead7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/handler.go
+++ b/cmd/handler.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Handler struct {
-	Config Config
+	Exporters []string
 }
 
 func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -30,8 +30,9 @@ func (h Handler) Merge(w io.Writer) error {
 	mfs := map[string]*prom.MetricFamily{}
 	tp := new(expfmt.TextParser)
 
-	for _, e := range h.Config.Exporters {
-		resp, err := http.Get(e.URL)
+	for _, url := range h.Exporters {
+		log.WithField("url", url).Debug("getting remote metrics")
+		resp, err := http.Get(url)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #4.

I think it is a bit ugly, but it works.

```
% ./exporter-merger -h
merges Prometheus metrics from multiple sources

Usage:
  exporter-merger [flags]
  exporter-merger [command]

Available Commands:
  help        Help about any command
  version     shows version of this application

Flags:
  -c, --config-path string   Path to the configuration file.
  -h, --help                 help for exporter-merger
      --listen-port int      Listen port for the HTTP server. (ENV:MERGER_PORT) (default 8080)
      --url stringSlice      URL to scrape. Can be speficied multiple times. (ENV:MERGER_URLS,space-seperated)

Use "exporter-merger [command] --help" for more information about a command.
```

I removed the default value for `--config-path`, which makes it a breaking change. Otherwise we would be required to specify `--config-path=""` to use env vars, which would be a bit awkward.

@rebuy-de/prp-exporter-merger Please review.
/cc @paskal