### PR TITLE
Add flags for exporter http timeout and log level

### DIFF
--- a/cmd/handler.go
+++ b/cmd/handler.go
@@ -13,7 +13,8 @@ import (
 )
 
 type Handler struct {
-	Exporters []string
+	Exporters            []string
+	ExportersHTTPTimeout int
 }
 
 func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -30,7 +31,7 @@ func (h Handler) Merge(w io.Writer) {
 	responses := make([]map[string]*prom.MetricFamily, 1024)
 	responsesMu := sync.Mutex{}
 
-	httpClientTimeout := time.Second * 10
+	httpClientTimeout := time.Second * time.Duration(h.ExportersHTTPTimeout)
 
 	wg := sync.WaitGroup{}
 	for _, url := range h.Exporters {

--- a/cmd/handler.go
+++ b/cmd/handler.go
@@ -30,7 +30,6 @@ func (h Handler) Merge(w io.Writer) {
 
 	responses := make([]map[string]*prom.MetricFamily, 1024)
 	responsesMu := sync.Mutex{}
-
 	httpClientTimeout := time.Second * time.Duration(h.ExportersHTTPTimeout)
 
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
Hi,
Another pull request to add flags for http timeout for connecting to exporter, and log level.

Warning! do not merge yet, I need your help with "log-level" flag. For some reason it always takes the default value (exporter timeout works)